### PR TITLE
File.Copy Fatal Crash Fix

### DIFF
--- a/SirenSharp/Services/ResourceGenerator.cs
+++ b/SirenSharp/Services/ResourceGenerator.cs
@@ -42,7 +42,7 @@ namespace SirenSharp.Services
 
                 foreach (var sound in soundSet.Sounds) // copy all files into raw dir to build awc
                 {
-                    File.Copy(sound.AudioPath, $"{awcDir.FullName}/{sound.FileName}");
+                    File.Copy(sound.AudioPath, $"{awcDir.FullName}/{sound.FileName}", true);
                 }
 
                 var awcXml = awcGenerator.GenerateAwcXml(soundSet);


### PR DESCRIPTION
`File.Copy(sound.AudioPath, $"{awcDir.FullName}/{sound.FileName}", true);`
Add override parameter to prevent unhandled system io file exists crash.
