### PR TITLE
Fix installer colliding with the app data folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,13 @@ jobs:
 
       - name: Build Velopack release
         if: steps.check.outputs.exists == 'false'
+        # Pack id is SirenSharpApp (not SirenSharp) on purpose: Velopack installs to
+        # %LocalAppData%\<id>, and the app already uses %LocalAppData%\SirenSharp for its
+        # own data (settings/projects/resources). Sharing that folder made Setup think the
+        # app was "already installed". A distinct install id keeps the two apart, so user
+        # data is untouched on install/update.
         run: >
-          vpk pack -u SirenSharp -v ${{ steps.ver.outputs.version }}
+          vpk pack -u SirenSharpApp -v ${{ steps.ver.outputs.version }}
           -p publish -e SirenSharp.exe --packTitle SirenSharp --icon SirenSharp/sirensharp.ico
 
       - name: Publish portable single-file (fallback)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ A FiveM tool for creating server sided sirens.
 
 Grab the latest build from the [releases](https://github.com/BJDubb/SirenSharp/releases/latest) page.
 
-- **Recommended:** run `SirenSharp-win-Setup.exe`. It installs the app and updates itself in the background - no re-downloading for new versions.
-- **Portable:** unzip `SirenSharp-...-portable-win-x64.zip` and run `SirenSharp.exe`. No auto-update; re-download to upgrade.
+- **Recommended:** run the Setup `.exe`. It installs the app and updates itself in the background - no re-downloading for new versions.
+- **Portable:** unzip the portable `.zip` and run `SirenSharp.exe`. No auto-update; re-download to upgrade.
 
 
 ## Discord

--- a/SirenSharp/SirenSharp.csproj
+++ b/SirenSharp/SirenSharp.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>sirensharp.ico</ApplicationIcon>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>


### PR DESCRIPTION
Velopack installed to %LocalAppData%\SirenSharp, the same folder the app uses for settings/projects/resources, so Setup.exe reported "already installed" and refused.

Packs under a distinct install id (SirenSharpApp) so the install dir no longer collides with the data folder. The app's data path is unchanged, so existing users keep their projects and recents. Version bumped to 0.5.1.

Note: the Setup/portable asset filenames change to reflect the new pack id; README wording made generic to match.